### PR TITLE
Make Advanced Cheat Menu compatible with More Spreadsheets

### DIFF
--- a/Advanced Cheat Menu + Cheat Events/gui/advcm_main.gui
+++ b/Advanced Cheat Menu + Cheat Events/gui/advcm_main.gui
@@ -1,5 +1,50 @@
 ﻿
 
+template cheat_menu_info_panel {
+	widget = {
+		layer = top
+
+		name = advcm_button
+		position = { 0 680}
+		size = { 40 40 }
+		using = Animation_ShowHide_Quick
+
+
+		sidepanel_button_small = {
+			name = "advcm_shortcut_button"
+			size = { 42 40 }
+			alpha = 0.7
+
+			onclick = "[ExecuteConsoleCommand('gui.createwidget gui/advcm_main.gui advcm_main_window')]"
+			#onclick = "[GetVariableSystem.Toggle('advcm_main_visible')]"
+			tooltip = advcm_button_tt
+
+			blockoverride "icon" {
+				texture = "gfx/interface/icons/military_icons/skull.dds"
+			}
+
+			blockoverride "icon_size" {
+				size = { 25 25 }
+			}
+
+			state = {
+				name = _mouse_enter
+				alpha = 1
+				duration = 0.7
+				using = Animation_Curve_Default
+			}
+
+			state = {
+				name = _mouse_leave
+				alpha = 0.7
+				duration = 0.2
+				using = Animation_Curve_Default
+			}
+		}
+	}
+}
+
+
 # This window is just for testing. You can spawn it from the console menu.
 
 window = {
@@ -11,29 +56,29 @@ window = {
 	filter_mouse = all
 	allow_outside = yes
 	alwaystransparent = no
-	
+
 	using = Window_Background
 	using = Window_Decoration
 	movable = yes
-    
+
     datacontext = "[GetVariableSystem]"
 	datacontext = "[GetPlayer]"
-	
-	
+
+
 	state = {
 		name = _show
 		using = Animation_FadeIn_Quick
 	}
-	
+
 	state = {
 		name = _hide
 		using = Animation_FadeOut_Quick
 	}
-	
+
 	vbox = {
 		restrictparent_min = yes
 		using = Window_Margins
-		
+
 		header_pattern = {
 			layoutpolicy_horizontal = expanding
 
@@ -48,11 +93,11 @@ window = {
 				onclick = "[ExecuteConsoleCommand('gui.clearwidgets')]"
 			}
 		}
-		
-		
+
+
 		widget = {
 			size = { 640 400 }
-			
+
 			widget = {
                 position = { 0 30 }
                 size = { 640 280 }
@@ -68,7 +113,7 @@ window = {
 							size = { 130 35 }
 							text = "Treasury"
 						}
-						
+
 						button_standard = {
 							name = "advcm_bureaucracy"
 							onclick = "[ExecuteConsoleCommand('event advcm.8')]"
@@ -78,7 +123,7 @@ window = {
 							size = { 130 35 }
 							text = "Bureaucracy"
 						}
-						
+
 						button_standard = {
 							name = "advcm_authority"
 							onclick = "[ExecuteConsoleCommand('event advcm.9')]"
@@ -88,7 +133,7 @@ window = {
 							size = { 130 35 }
 							text = "Authority"
 						}
-						
+
 						button_standard = {
 							name = "advcm_influence"
 							onclick = "[ExecuteConsoleCommand('event advcm.10')]"
@@ -98,9 +143,9 @@ window = {
 							size = { 130 35 }
 							text = "Influence"
 						}
-					
+
 					}
-					
+
 					hbox = {
 						button_standard = {
 							name = "advcm_loyalists"
@@ -111,7 +156,7 @@ window = {
 							size = { 130 35 }
 							text = "Loyalists"
 						}
-						
+
 						button_standard = {
 							name = "advcm_radicals"
 							onclick = "[ExecuteConsoleCommand('event advcm.4')]"
@@ -121,7 +166,7 @@ window = {
 							size = { 130 35 }
 							text = "Radicals"
 						}
-						
+
 						button_standard = {
 							name = "advcm_tech_spread"
 							onclick = "[ExecuteConsoleCommand('event advcm.11')]"
@@ -142,7 +187,7 @@ window = {
 							size = { 130 35 }
 							text = "Infamy"
 						}
-					
+
 					}
 
 					hbox = {
@@ -155,7 +200,7 @@ window = {
 							size = { 130 35 }
 							text = "Hardcore Introvert"
 						}
-						
+
 						button_standard = {
 							name = "advcm_isolationist_lite"
 							onclick = "[ExecuteConsoleCommand('event advcm.12')]"
@@ -164,7 +209,7 @@ window = {
 							size = { 130 35 }
 							text = "Introvert-Lite"
 						}
-						
+
 						button_standard = {
 							name = "advcm_empire_protec"
 							onclick = "[ExecuteConsoleCommand('event advcm.15')]"
@@ -173,7 +218,7 @@ window = {
 							size = { 130 35 }
 							text = "Empire-Protec"
 						}
-						
+
 						button_standard = {
 							name = "advcm_empire_attac"
 							onclick = "[ExecuteConsoleCommand('event advcm.16')]"
@@ -182,9 +227,9 @@ window = {
 							size = { 130 35 }
 							text = "Empire-Attac"
 						}
-					
+
 					}
-					
+
 					hbox = {
 						button_standard = {
 							name = "advcm_ancap"
@@ -194,7 +239,7 @@ window = {
 							size = { 130 35 }
 							text = "An-Capistan"
 						}
-						
+
 						button_standard = {
 							name = "advcm_rob_bar_par"
 							onclick = "[ExecuteConsoleCommand('event advcm.19')]"
@@ -203,7 +248,7 @@ window = {
 							size = { 130 35 }
 							text = "Robber Barron's"
 						}
-						
+
 						button_standard = {
 							name = "advcm_syndi"
 							onclick = "[ExecuteConsoleCommand('event advcm.17')]"
@@ -222,7 +267,7 @@ window = {
 							size = { 130 35 }
 							text = "Lenin's Legacy"
 						}
-					
+
 					}
 
 					hbox = {
@@ -235,7 +280,7 @@ window = {
 							size = { 130 35 }
 							text = "Growth Serum"
 						}
-						
+
 						button_standard = {
 							name = "advcm_build"
 							onclick = "[ExecuteConsoleCommand('fastbuild')]"
@@ -244,7 +289,7 @@ window = {
 							size = { 130 35 }
 							text = "Construction Drive"
 						}
-						
+
 						button_standard = {
 							name = "advcm_enact"
 							onclick = "[ExecuteConsoleCommand('fastenact')]"
@@ -263,7 +308,7 @@ window = {
 							size = { 130 35 }
 							text = "Brainiac"
 						}
-					
+
 					}
 
 					hbox = {
@@ -275,7 +320,7 @@ window = {
 							size = { 130 35 }
 							text = "Bardic Charisma"
 						}
-						
+
 						button_standard = {
 							name = "advcm_taxation"
 							onclick = "[ExecuteConsoleCommand('event advcm.28')]"
@@ -285,7 +330,7 @@ window = {
 							size = { 130 35 }
 							text = "Quantitative Easing"
 						}
-						
+
 						button_standard = {
 							name = "advcm_eff"
 							onclick = "[ExecuteConsoleCommand('event advcm.38')]"
@@ -306,7 +351,7 @@ window = {
 							size = { 130 35 }
 							text = "Robot Factories!"
 						}
-					
+
 					}
 
 					hbox = {
@@ -319,7 +364,7 @@ window = {
 							size = { 130 35 }
 							text = "The Killing Fields"
 						}
-						
+
 						button_standard = {
 							name = "advcm_recovery"
 							onclick = "[ExecuteConsoleCommand('event advcm.36')]"
@@ -329,7 +374,7 @@ window = {
 							size = { 130 35 }
 							text = "The Immortals"
 						}
-						
+
 						button_standard = {
 							name = "advcm_attac"
 							onclick = "[ExecuteConsoleCommand('event advcm.32')]"
@@ -349,11 +394,11 @@ window = {
 							size = { 130 35 }
 							text = "The Great Protec"
 						}
-					
+
 					}
 				}
-            }			
-			
+            }
+
             widget = {
                 position = { 265 350 }
                 size = { 110 40 }
@@ -367,9 +412,9 @@ window = {
                     }
                 }
 			}
-			
-		}            
-	
+
+		}
+
 	}
-	
+
 }

--- a/Advanced Cheat Menu + Cheat Events/gui/information_panel_bar.gui
+++ b/Advanced Cheat Menu + Cheat Events/gui/information_panel_bar.gui
@@ -1,4 +1,4 @@
-#positions for sidepanel buttons 
+#positions for sidepanel buttons
 #(they cant be in flowcontainer because of the way the label buttons is set up to scale with the longest localized text)
 @budget_position = 50
 @buildings_position = 100
@@ -27,7 +27,7 @@ types information_panel_bar_types {
 		focuspolicy = all
 
 		position = { 0 200 }
-		
+
 		state = {
 			name = _show
 			using = default_show_properties
@@ -37,13 +37,13 @@ types information_panel_bar_types {
 			using = default_hide_properties
 			on_start = "[InformationPanelBar.ClosePanel]"
 		}
-		
+
 		### BACKGROUND FOR LABEL BUTTONS
 		widget = {
 			size = { 100% 100% }
 			using = clickthrough_blocker
 			alpha = 0
-			
+
 			background = {
 				using = dark_area
 				alpha = 1
@@ -51,7 +51,7 @@ types information_panel_bar_types {
 				margin_top = -5
 				margin_left = -25
 				margin_bottom = -5
-				
+
 				modify_texture = {
 					texture = "gfx/interface/masks/fade_horizontal_right.dds"
 					spriteType = Corneredstretched
@@ -59,7 +59,7 @@ types information_panel_bar_types {
 					blend_mode = alphamultiply
 				}
 			}
-			
+
 			state = {
 				name = show_sidebar_labels
 				alpha = 0.7
@@ -85,7 +85,7 @@ types information_panel_bar_types {
 			texture = "gfx/interface/main_hud/sidebar_bg.dds"
 			size = { 50 620 }
 			position = { 0 -17 }
-			
+
 			using = hud_shiny_effect
 		}
 
@@ -97,7 +97,7 @@ types information_panel_bar_types {
 			margin_right = -8 #margin to trim the hover area for the labels
 			onmousehierarchyenter = "[PdxGuiInterruptThenTriggerAllAnimations('hide_sidebar_labels','show_sidebar_labels')]"
 			onmousehierarchyleave = "[PdxGuiInterruptThenTriggerAllAnimations('show_sidebar_labels','hide_sidebar_labels')]"
-			
+
 			container = {
 				### POLITICS
 				sidebar_label_button = {
@@ -127,7 +127,7 @@ types information_panel_bar_types {
 							visible = "[InformationPanelBar.IsPanelOpen('politics')]"
 						}
 						onclick = "[InformationPanelBar.OpenPanelCycleTabs('politics', 'overview|interest_groups|laws|institutions')]"
-						
+
 						animated_progresspie = {
 							parentanchor = center
 							texture = "gfx/interface/main_hud/sidebar_progress.dds"
@@ -145,7 +145,7 @@ types information_panel_bar_types {
 					tooltip = "BUTTON_POLITICS"
 					shortcut = "open_politics"
 				}
-				
+
 				### BUDGET
 				sidebar_label_button = {
 					position = { -100 @budget_position }
@@ -182,7 +182,7 @@ types information_panel_bar_types {
 					tooltip = "BUTTON_BUDGET"
 					shortcut = "open_budget"
 				}
-				
+
 				### BUILDINGS
 				sidebar_label_button = {
 					position = { -100 @buildings_position }
@@ -219,7 +219,7 @@ types information_panel_bar_types {
 					tooltip = "BUTTON_BUILDINGS"
 					shortcut = "open_buildings"
 				}
-				
+
 				### TRADE OVERVIEW
 				sidebar_label_button = {
 					position = { -100 @trade_position }
@@ -256,7 +256,7 @@ types information_panel_bar_types {
 					tooltip = "BUTTON_TRADE_OVERVIEW"
 					shortcut = "open_market"
 				}
-				
+
 				### MILITARY
 				sidebar_label_button = {
 					position = { -100 @military_position }
@@ -293,16 +293,16 @@ types information_panel_bar_types {
 					tooltip = "BUTTON_MILITARY"
 					shortcut = "open_military"
 				}
-				
+
 				### SECONDARY BUTTONS
-				
+
 				#widget needed to prevent you from clicking on the map
 				widget = {
 					using = clickthrough_blocker
 					position = { 0 @spacing_widget_1_position }
 					size = { 100% @spacing_widget_size }
 				}
-				
+
 				### DIPLOMATIC
 				sidebar_label_button_small = {
 					enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
@@ -341,7 +341,7 @@ types information_panel_bar_types {
 					tooltip = "BUTTON_DIPLOMATIC_OVERVIEW"
 					shortcut = "open_diplomatic"
 				}
-				
+
 				### TECHNOLOGY
 				sidebar_label_button_small = {
 					enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
@@ -373,7 +373,7 @@ types information_panel_bar_types {
 							visible = "[InformationPanelBar.IsPanelOpen('tech_tree')]"
 						}
 						onclick = "[InformationPanelBar.OpenPanelCycleTabs('tech_tree', 'production|military|society')]"
-						
+
 						animated_progresspie = {
 							visible = "[Technology.IsValid]"
 							parentanchor = center
@@ -392,7 +392,7 @@ types information_panel_bar_types {
 					tooltip = "BUTTON_TECHNOLOGY"
 					shortcut = "open_technology"
 				}
-				
+
 				### CULTURE
 				sidebar_label_button_small = {
 					enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
@@ -431,7 +431,7 @@ types information_panel_bar_types {
 					tooltip = "BUTTON_CULTURE_OVERVIEW"
 					shortcut = "open_culture"
 				}
-				
+
 				### POPULATION
 				sidebar_label_button_small = {
 					enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
@@ -470,7 +470,7 @@ types information_panel_bar_types {
 					tooltip = "BUTTON_POPULATION"
 					shortcut = "open_population"
 				}
-				
+
 				### JOURNAL
 				sidebar_label_button_small = {
 					enabled = "[GetMetaPlayer.GetPlayedOrObservedCountry.IsValid]"
@@ -562,7 +562,7 @@ types information_panel_bar_types {
 					tooltip = "OUTLINER_TOOLTIP"
 					shortcut = "open_outliner"
 				}
-				
+
 				#widget needed to prevent you from clicking on the map
 				widget = {
 					using = clickthrough_blocker
@@ -579,12 +579,12 @@ types information_panel_bar_types {
 						shortcut = map_list
 					}
 				}
-				
+
 				sidebar_label_text_small = {
 					position = { -100 @maplist_position }
 					text = "MAP_LIST"
 				}
-				
+
 				widget = {
 					position = { 0 @maplist_position }
 					using = clickthrough_blocker
@@ -612,53 +612,13 @@ types information_panel_bar_types {
 			}
 		}
 
-		widget = {
-			layer = top
-			
-			name = advcm_button
-			position = { 0 600}
-			size = { 40 40 }
-			using = Animation_ShowHide_Quick
-			
-
-			sidepanel_button_small = {
-				name = "advcm_shortcut_button"
-				size = { 42 40 }
-				alpha = 0.7
-
-				onclick = "[ExecuteConsoleCommand('gui.createwidget gui/advcm_main.gui advcm_main_window')]"
-				#onclick = "[GetVariableSystem.Toggle('advcm_main_visible')]"
-				tooltip = advcm_button_tt
-				
-				blockoverride "icon" {
-					texture = "gfx/interface/icons/military_icons/skull.dds"
-				}
-				
-				blockoverride "icon_size" {
-					size = { 25 25 }
-				}
-				
-				state = {
-					name = _mouse_enter
-					alpha = 1
-					duration = 0.7
-					using = Animation_Curve_Default
-				}
-
-				state = {
-					name = _mouse_leave
-					alpha = 0.7
-					duration = 0.2
-					using = Animation_Curve_Default
-				}
-			}
-		}
+		using = cheat_menu_info_panel
 	}
 }
 
-template sidebar_button_size { 
-	size = { 48 50 } 
+template sidebar_button_size {
+	size = { 48 50 }
 }
-template sidebar_button_size_small { 
+template sidebar_button_size_small {
 	size = { 42 40 }
 }


### PR DESCRIPTION
We didn't manage to connect on steam. This way works better anyways :)

Moved your widget from information_panel_bar.gui to a template in advc_main.gui.
Then included your template in my mod and also in your information_panel_bar.gui.

Now as long as people load my mod after yours we are compatible, nothing else changed for your mod.

Sidenote: There seems to be a difference in crlf vs lf, which happened automatically on my git commit converting everything to crlf.

